### PR TITLE
QP-2337 Add DynamoDB AssumeRole credential

### DIFF
--- a/PrimarSql.Data/PrimarSqlConnection.cs
+++ b/PrimarSql.Data/PrimarSqlConnection.cs
@@ -170,6 +170,24 @@ namespace PrimarSql.Data
                 return profile.GetAWSCredentials(sharedFile);
             }
 
+            if (!string.IsNullOrWhiteSpace(builder.TargetRoleArn) &&
+                !string.IsNullOrWhiteSpace(builder.ExternalId))
+            {
+                var opt = new AssumeRoleAWSCredentialsOptions
+                {
+                    ExternalId = builder.ExternalId,
+                    // Credential will expire after 1 hour
+                    DurationSeconds = 60 * 60
+                };
+
+                return new AssumeRoleAWSCredentials(
+                    FallbackCredentialsFactory.GetCredentials(),
+                    builder.TargetRoleArn,
+                    Guid.NewGuid().ToString(),
+                    opt
+                );
+            }
+
             if (!string.IsNullOrWhiteSpace(builder.ProfileName))
             {
                 // Credentials from config

--- a/PrimarSql.Data/PrimarSqlConnection.cs
+++ b/PrimarSql.Data/PrimarSqlConnection.cs
@@ -176,8 +176,7 @@ namespace PrimarSql.Data
                 var opt = new AssumeRoleAWSCredentialsOptions
                 {
                     ExternalId = builder.ExternalId,
-                    // Credential will expire after 1 hour
-                    DurationSeconds = 60 * 60
+                    DurationSeconds = builder.DurationSeconds
                 };
 
                 return new AssumeRoleAWSCredentials(

--- a/PrimarSql.Data/PrimarSqlConnectionStringBuilder.cs
+++ b/PrimarSql.Data/PrimarSqlConnectionStringBuilder.cs
@@ -54,6 +54,18 @@ namespace PrimarSql.Data
             get => GetValue<string>(nameof(ClientName));
             set => SetValue(nameof(ClientName), value);
         }
+
+        public string ExternalId
+        {
+            get => GetValue<string>(nameof(ExternalId));
+            set => SetValue(nameof(ExternalId), value);
+        }
+
+        public string TargetRoleArn
+        {
+            get => GetValue<string>(nameof(TargetRoleArn));
+            set => SetValue(nameof(TargetRoleArn), value);
+        }
         #endregion
 
         #region Constructor

--- a/PrimarSql.Data/PrimarSqlConnectionStringBuilder.cs
+++ b/PrimarSql.Data/PrimarSqlConnectionStringBuilder.cs
@@ -66,6 +66,12 @@ namespace PrimarSql.Data
             get => GetValue<string>(nameof(TargetRoleArn));
             set => SetValue(nameof(TargetRoleArn), value);
         }
+
+        public int DurationSeconds
+        {
+            get => GetValue<int>(nameof(DurationSeconds));
+            set => SetValue(nameof(DurationSeconds), value);
+        }
         #endregion
 
         #region Constructor


### PR DESCRIPTION
DynamoDB의 Credentials 생성 방식으로 Assume Role을 추가로 지원합니다.

ConnectionStringBuilder에 TargetRoleArn과 ExternalId가 있을 경우 AssumeRoleAWSCredentials를 생성해 반환합니다.