### PR TITLE
[QP-2722] Number Type의 값이 지수 형태로 표현되지 않도록 개선

### DIFF
--- a/PrimarSql.Data/Models/JDynamoDBNumber.cs
+++ b/PrimarSql.Data/Models/JDynamoDBNumber.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace PrimarSql.Data.Models;
+
+public class JDynamoDBNumber : JValue
+{
+    public JDynamoDBNumber(string value) : base(value)
+    {
+    }
+
+    public override async Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+    {
+        await writer.WriteRawValueAsync(Value?.ToString(), cancellationToken);
+    }
+
+    public override void WriteTo(JsonWriter writer, params JsonConverter[] converters)
+    {
+        writer.WriteRawValue(Value?.ToString());
+    }
+}

--- a/PrimarSql.Data/PrimarSql.Data.csproj
+++ b/PrimarSql.Data/PrimarSql.Data.csproj
@@ -14,7 +14,7 @@
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <RepositoryUrl>https://github.com/chequer-io/PrimarSql.Data</RepositoryUrl>
         <PackageProjectUrl>https://github.com/chequer-io/PrimarSql.Data</PackageProjectUrl>
-        <Version>1.3.2</Version>
+        <Version>1.3.3</Version>
         <PackageIcon>Logo.png</PackageIcon>
         <PackageTags>sql;primarsql;dynamodb;nosql;ado.net;connector;primarsql.data</PackageTags>
     </PropertyGroup>

--- a/PrimarSql.Data/Utilities/AttributeValueUtility.cs
+++ b/PrimarSql.Data/Utilities/AttributeValueUtility.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Amazon.DynamoDBv2.Model;
 using Newtonsoft.Json.Linq;
+using PrimarSql.Data.Models;
 
 namespace PrimarSql.Data.Utilities
 {
@@ -42,10 +43,10 @@ namespace PrimarSql.Data.Utilities
                 return new JArray(value.SS);
 
             if (value.NS.Count > 0)
-                return new JArray(value.NS.Select(double.Parse));
+                return new JArray(value.NS.Select(n => new JDynamoDBNumber(n)));
             
             if (!string.IsNullOrEmpty(value.N))
-                return new JValue(double.Parse(value.N));
+                return new JDynamoDBNumber(value.N);
 
             return value.S;
         }


### PR DESCRIPTION
## What is this PR? 🔍
DynamoDB의 number 값 조회 시, 조회된 값이 8.4737E+17 (예시)와 같이 지수 형태로 출력되지 않도록 해달라는 고객사 요청에 따른 개선입니다.


## Changes 📝
JDynamoDBNumber class
DynamoDB로부터 Number Type의 값을 받을 때 JDynamoDBNumber class를 return하도록 변경

## Issue 📌
https://chequer.atlassian.net/browse/QD-2722